### PR TITLE
chore: upgrade Garble version

### DIFF
--- a/Utils/Utils.go
+++ b/Utils/Utils.go
@@ -38,7 +38,7 @@ func CheckGarble() {
 	if _, err := os.Stat(cwd + "/.lib/garble"); err == nil {
 	} else {
 		fmt.Println("[!] Missing Garble... Downloading it now")
-		cmd = exec.Command(bin, "GOBIN="+cwd+"/.lib/", "go", "install", "mvdan.cc/garble@v0.7.2")
+		cmd = exec.Command(bin, "GOBIN="+cwd+"/.lib/", "go", "install", "mvdan.cc/garble@v0.9.1")
 		var out bytes.Buffer
 		var stderr bytes.Buffer
 		cmd.Stdout = &out


### PR DESCRIPTION
Currently Freeze works only when upgrading garble on my computer. With 0.7.2 I have: 
```
[*] Compiling Payload
exit status 1: # runtime
panic: runtime listed a std package we can't find: arena
```